### PR TITLE
Remove update customer dialog and related functionality

### DIFF
--- a/changelog_generator/views/table.py
+++ b/changelog_generator/views/table.py
@@ -1,7 +1,6 @@
 import reflex as rx
 
 from changelog_generator.backend.backend import GithubPullRequest, State
-from changelog_generator.components.form_field import form_field
 from changelog_generator.components.gender_badges import gender_badge
 
 
@@ -53,7 +52,6 @@ def _show_pull_request(pull_request: GithubPullRequest):
                         disabled=State.gen_response,
                     ),
                 ),
-                _update_customer_dialog(pull_request),
                 rx.icon_button(
                     rx.icon("trash-2", size=22),
                     on_click=lambda: State.delete_pull_request(pull_request.id),
@@ -66,169 +64,6 @@ def _show_pull_request(pull_request: GithubPullRequest):
         ),
         style={"_hover": {"bg": rx.color("accent", 2)}},
         align="center",
-    )
-
-
-def _update_customer_dialog(pull_request):
-    return rx.dialog.root(
-        rx.dialog.trigger(
-            rx.icon_button(
-                rx.icon("square-pen", size=22),
-                color_scheme="green",
-                size="2",
-                variant="solid",
-                on_click=lambda: State.get_pull_request(pull_request),
-            ),
-        ),
-        rx.dialog.content(
-            rx.hstack(
-                rx.badge(
-                    rx.icon(tag="square-pen", size=34),
-                    color_scheme="blue",
-                    radius="full",
-                    padding="0.65rem",
-                ),
-                rx.vstack(
-                    rx.dialog.title(
-                        "Edit Customer",
-                        weight="bold",
-                        margin="0",
-                    ),
-                    rx.dialog.description(
-                        "Edit the customer's info",
-                    ),
-                    spacing="1",
-                    height="100%",
-                    align_items="start",
-                ),
-                height="100%",
-                spacing="4",
-                margin_bottom="1.5em",
-                align_items="center",
-                width="100%",
-            ),
-            rx.flex(
-                rx.form.root(
-                    rx.flex(
-                        rx.hstack(
-                            # Name
-                            form_field(
-                                "Name",
-                                "Customer Name",
-                                "text",
-                                "customer_name",
-                                "user",
-                                pull_request.customer_name,
-                            ),
-                            # Location
-                            form_field(
-                                "Location",
-                                "Customer Location",
-                                "text",
-                                "location",
-                                "map-pinned",
-                                pull_request.location,
-                            ),
-                            spacing="3",
-                            width="100%",
-                        ),
-                        rx.hstack(
-                            # Email
-                            form_field(
-                                "Email",
-                                "user@reflex.dev",
-                                "email",
-                                "email",
-                                "mail",
-                                pull_request.email,
-                            ),
-                            # Job
-                            form_field(
-                                "Job",
-                                "Customer Job",
-                                "text",
-                                "job",
-                                "briefcase",
-                                pull_request.job,
-                            ),
-                            spacing="3",
-                            width="100%",
-                        ),
-                        # Gender
-                        rx.vstack(
-                            rx.hstack(
-                                rx.icon("user-round", size=16, stroke_width=1.5),
-                                rx.text("Gender"),
-                                align="center",
-                                spacing="2",
-                            ),
-                            rx.select(
-                                ["Male", "Female", "Other"],
-                                default_value=pull_request.gender,
-                                name="gender",
-                                direction="row",
-                                as_child=True,
-                                required=True,
-                                width="100%",
-                            ),
-                            width="100%",
-                        ),
-                        rx.hstack(
-                            # Age
-                            form_field(
-                                "Age",
-                                "Customer Age",
-                                "number",
-                                "age",
-                                "person-standing",
-                                pull_request.age.to(str),
-                            ),
-                            # Salary
-                            form_field(
-                                "Salary",
-                                "Customer Salary",
-                                "number",
-                                "salary",
-                                "dollar-sign",
-                                pull_request.salary.to(str),
-                            ),
-                            spacing="3",
-                            width="100%",
-                        ),
-                        direction="column",
-                        spacing="3",
-                    ),
-                    rx.flex(
-                        rx.dialog.close(
-                            rx.button(
-                                "Cancel",
-                                variant="soft",
-                                color_scheme="gray",
-                            ),
-                        ),
-                        rx.form.submit(
-                            rx.dialog.close(
-                                rx.button("Update Customer"),
-                            ),
-                            as_child=True,
-                        ),
-                        padding_top="2em",
-                        spacing="3",
-                        mt="4",
-                        justify="end",
-                    ),
-                    on_submit=State.update_customer_to_db,
-                    reset_on_submit=False,
-                ),
-                width="100%",
-                direction="column",
-                spacing="4",
-            ),
-            max_width="450px",
-            padding="1.5em",
-            border=f"2px solid {rx.color('accent', 7)}",
-            border_radius="25px",
-        ),
     )
 
 


### PR DESCRIPTION
This pull request removes the `_update_customer_dialog` function and its associated import from the `table.py` file. The function was responsible for rendering a dialog to edit customer information. Its removal simplifies the code and eliminates the ability to update customer details directly from the table view.

The changes also include:
- Removing the import of `form_field` component
- Deleting the call to `_update_customer_dialog` within the `_show_pull_request` function

These modifications streamline the table view by removing the edit functionality for individual customer entries.
