### PR TITLE
Add repository URL and release tag inputs

### DIFF
--- a/changelog_generator/backend/backend.py
+++ b/changelog_generator/backend/backend.py
@@ -64,6 +64,10 @@ class State(rx.State):
 
     current_pull_request: GithubPullRequest = GithubPullRequest()
     pull_requests: list[GithubPullRequest] = []
+    release_tag_start: str = ""
+    release_tag_end: str = ""
+    repository_url: str = ""
+
     products: dict[str, str] = {}
     email_content_data: str = (
         "Click 'Generate Changelog' make an AI generated changelog."
@@ -74,6 +78,27 @@ class State(rx.State):
     search_value: str = ""
     sort_value: str = ""
     sort_reverse: bool = False
+
+    def set_repository_url(
+        self,
+        value: str,
+    ) -> None:
+        self.repository_url = value
+        print(self.repository_url)
+
+    def set_release_tag_start(
+        self,
+        value: str,
+    ) -> None:
+        self.release_tag_start = value
+        print(self.release_tag_start)
+
+    def set_release_tag_end(
+        self,
+        value: str,
+    ) -> None:
+        self.release_tag_end = value
+        print(self.release_tag_end)
 
     def load_entries(self) -> list[GithubPullRequest]:
         """Get all users from the database."""

--- a/changelog_generator/views/table.py
+++ b/changelog_generator/views/table.py
@@ -70,24 +70,33 @@ def _show_pull_request(pull_request: GithubPullRequest):
 def main_table():
     return rx.fragment(
         rx.flex(
-            rx.spacer(),
-            rx.cond(
-                State.sort_reverse,
-                rx.icon(
-                    "arrow-down-z-a",
-                    size=28,
-                    stroke_width=1.5,
-                    cursor="pointer",
-                    on_click=State.toggle_sort,
+            rx.flex(
+                rx.input(
+                    placeholder="Repository url",
+                    size="3",
+                    max_width="225px",
+                    width="100%",
+                    variant="surface",
+                    on_change=lambda value: State.set_repository_url(value),
                 ),
-                rx.icon(
-                    "arrow-down-a-z",
-                    size=28,
-                    stroke_width=1.5,
-                    cursor="pointer",
-                    on_click=State.toggle_sort,
+                rx.input(
+                    placeholder="Start tag",
+                    size="3",
+                    max_width="225px",
+                    width="100%",
+                    variant="surface",
+                    on_change=lambda value: State.set_release_tag_start(value),
+                ),
+                rx.input(
+                    placeholder="End tag",
+                    size="3",
+                    max_width="225px",
+                    width="100%",
+                    variant="surface",
+                    on_change=lambda value: State.set_release_tag_end(value),
                 ),
             ),
+            rx.spacer(),
             rx.select(
                 [
                     "customer_name",
@@ -101,15 +110,6 @@ def main_table():
                 placeholder="Sort By: Name",
                 size="3",
                 on_change=lambda sort_value: State.sort_values(sort_value),
-            ),
-            rx.input(
-                rx.input.slot(rx.icon("search")),
-                placeholder="Search here...",
-                size="3",
-                max_width="225px",
-                width="100%",
-                variant="surface",
-                on_change=lambda value: State.filter_values(value),
             ),
             justify="end",
             align="center",


### PR DESCRIPTION
This pull request adds new functionality to the changelog generator:

1. Introduced new state variables for repository URL, release tag start, and release tag end.
2. Added methods to set these new state variables.
3. Updated the main table view to include input fields for repository URL, start tag, and end tag.
4. Removed the search input and sorting icons from the table view.
5. Adjusted the layout of the table controls to accommodate the new input fields.

These changes allow users to specify the repository and release tags for generating changelogs, providing more flexibility and control over the changelog generation process.
