### PR TITLE
Remove sorting functionality from pull request query

### DIFF
--- a/changelog_generator/backend/backend.py
+++ b/changelog_generator/backend/backend.py
@@ -4,7 +4,7 @@ import os
 
 import openai
 import reflex as rx
-from sqlmodel import asc, desc, func, or_, select
+from sqlmodel import or_, select
 
 from .models import GithubPullRequest
 
@@ -114,20 +114,6 @@ class State(rx.State):
                         ],
                     ),
                 )
-
-            if self.sort_value:
-                sort_column = getattr(GithubPullRequest, self.sort_value)
-                if self.sort_value == "salary":
-                    order = desc(sort_column) if self.sort_reverse else asc(sort_column)
-
-                else:
-                    order = (
-                        desc(func.lower(sort_column))
-                        if self.sort_reverse
-                        else asc(func.lower(sort_column))
-                    )
-
-                query = query.order_by(order)
 
             self.pull_requests = session.exec(query).all()
 


### PR DESCRIPTION
This pull request removes the sorting functionality from the `State` class in the `backend.py` file. The changes include:

1. Removing unused imports: `asc`, `desc`, and `func` from `sqlmodel`.
2. Eliminating the sorting logic that was previously applied to the database query.
3. Simplifying the query execution by removing the `order_by` clause.

These changes streamline the code and remove unused sorting capabilities, potentially improving query performance.
