### PR TITLE
Remove sort select and adjust input layout

### DIFF
--- a/changelog_generator/views/table.py
+++ b/changelog_generator/views/table.py
@@ -60,6 +60,9 @@ def main_table():
                     variant="surface",
                     on_change=lambda value: State.set_repository_url(value),
                 ),
+            ),
+            rx.spacer(),
+            rx.flex(
                 rx.input(
                     placeholder="Start tag",
                     size="3",
@@ -76,21 +79,6 @@ def main_table():
                     variant="surface",
                     on_change=lambda value: State.set_release_tag_end(value),
                 ),
-            ),
-            rx.spacer(),
-            rx.select(
-                [
-                    "customer_name",
-                    "email",
-                    "age",
-                    "gender",
-                    "location",
-                    "job",
-                    "salary",
-                ],
-                placeholder="Sort By: Name",
-                size="3",
-                on_change=lambda sort_value: State.sort_values(sort_value),
             ),
             justify="end",
             align="center",


### PR DESCRIPTION
This pull request modifies the layout of the main table view in the changelog generator. It reorganizes the input fields for the repository URL, start tag, and end tag into separate flex containers for improved visual structure. The sort-by dropdown menu has been removed, simplifying the user interface and focusing on the essential inputs for generating changelogs.
