### PR TITLE
Remove product catalog and refactor email generation for changelog

### DIFF
--- a/changelog_generator/backend/backend.py
+++ b/changelog_generator/backend/backend.py
@@ -4,7 +4,7 @@ import os
 
 import openai
 import reflex as rx
-from sqlmodel import asc, desc, func, or_, select
+from sqlmodel import or_, select
 
 from .models import GithubPullRequest
 
@@ -114,20 +114,6 @@ class State(rx.State):
                         ],
                     ),
                 )
-
-            if self.sort_value:
-                sort_column = getattr(GithubPullRequest, self.sort_value)
-                if self.sort_value == "salary":
-                    order = desc(sort_column) if self.sort_reverse else asc(sort_column)
-
-                else:
-                    order = (
-                        desc(func.lower(sort_column))
-                        if self.sort_reverse
-                        else asc(func.lower(sort_column))
-                    )
-
-                query = query.order_by(order)
 
             self.pull_requests = session.exec(query).all()
 

--- a/changelog_generator/backend/backend.py
+++ b/changelog_generator/backend/backend.py
@@ -8,46 +8,6 @@ from sqlmodel import or_, select
 
 from .models import GithubPullRequest
 
-products: dict[str, dict] = {
-    "T-shirt": {
-        "description": "A plain white t-shirt made of 100% cotton.",
-        "price": 10.99,
-    },
-    "Jeans": {
-        "description": "A pair of blue denim jeans with a straight leg fit.",
-        "price": 24.99,
-    },
-    "Hoodie": {
-        "description": "A black hoodie made of a cotton and polyester blend.",
-        "price": 34.99,
-    },
-    "Cardigan": {
-        "description": "A grey cardigan with a V-neck and long sleeves.",
-        "price": 36.99,
-    },
-    "Joggers": {
-        "description": "A pair of black joggers made of a cotton and polyester blend.",
-        "price": 44.99,
-    },
-    "Dress": {"description": "A black dress made of 100% polyester.", "price": 49.99},
-    "Jacket": {
-        "description": "A navy blue jacket made of 100% cotton.",
-        "price": 55.99,
-    },
-    "Skirt": {
-        "description": "A brown skirt made of a cotton and polyester blend.",
-        "price": 29.99,
-    },
-    "Shorts": {
-        "description": "A pair of black shorts made of a cotton and polyester blend.",
-        "price": 19.99,
-    },
-    "Sweater": {
-        "description": "A white sweater with a crew neck and long sleeves.",
-        "price": 39.99,
-    },
-}
-
 _client = None
 
 
@@ -172,7 +132,7 @@ class State(rx.State):
                 },
                 {
                     "role": "user",
-                    "content": f"Based on these {products} write a sales email to {self.current_pull_request.customer_name} and email {self.current_pull_request.email} who is {self.current_pull_request.age} years old and a {self.current_pull_request.gender} gender. {self.current_pull_request.customer_name} lives in {self.current_pull_request.location} and works as a {self.current_pull_request.job} and earns {self.current_pull_request.salary} per year. Make sure the email recommends one product only and is personalized to {self.current_pull_request.customer_name}. The company is named Reflex its website is https://reflex.dev.",
+                    "content": f"Based on these {self.pull_requests} write a changelog draft to junior level developer",
                 },
             ],
         )
@@ -188,8 +148,7 @@ class State(rx.State):
         async with self:
             self.gen_response = False
 
-    def generate_email(self, user: GithubPullRequest):
-        self.current_pull_request = GithubPullRequest(**user)
+    def generate_email(self):
         self.gen_response = True
         self.email_content_data = ""
         return State.call_openai

--- a/changelog_generator/views/email.py
+++ b/changelog_generator/views/email.py
@@ -79,6 +79,11 @@ def email_gen_ui():
     return (
         rx.card(
             rx.flex(
+                rx.button(
+                    "Generate Changelog",
+                    on_click=State.generate_email,
+                    width="100%",
+                ),
                 email_box(),
                 rx.divider(),
                 options(),

--- a/changelog_generator/views/email.py
+++ b/changelog_generator/views/email.py
@@ -21,7 +21,10 @@ def email_box():
                 right="1px",
                 z_index="10",
             ),
-            rx.text(State.email_content_data, line_height="1.75"),
+            rx.text(
+                State.email_content_data,
+                line_height="1.75",
+            ),
             type="auto",
             scrollbars="vertical",
             height="100%",
@@ -35,7 +38,10 @@ def email_box():
 def options():
     return rx.vstack(
         rx.vstack(
-            rx.heading(f"Length limit: {State.length}", size="5"),
+            rx.heading(
+                f"Length limit: {State.length}",
+                size="5",
+            ),
             rx.slider(
                 min=500,
                 max=1500,

--- a/changelog_generator/views/table.py
+++ b/changelog_generator/views/table.py
@@ -60,6 +60,9 @@ def main_table():
                     variant="surface",
                     on_change=lambda value: State.set_repository_url(value),
                 ),
+            ),
+            rx.spacer(),
+            rx.flex(
                 rx.input(
                     placeholder="Start tag",
                     size="3",
@@ -76,21 +79,6 @@ def main_table():
                     variant="surface",
                     on_change=lambda value: State.set_release_tag_end(value),
                 ),
-            ),
-            rx.spacer(),
-            rx.select(
-                [
-                    "customer_name",
-                    "email",
-                    "age",
-                    "gender",
-                    "location",
-                    "job",
-                    "salary",
-                ],
-                placeholder="Sort By: Name",
-                size="3",
-                on_change=lambda sort_value: State.sort_values(sort_value),
             ),
             justify="end",
             align="center",


### PR DESCRIPTION
This pull request removes the `products` dictionary and modifies the OpenAI prompt generation logic. The changes focus on generating a changelog draft for junior-level developers based on pull requests, rather than creating personalized sales emails.

The `generate_email` function has been simplified, removing the need for a user parameter. A new "Generate Changelog" button has been added to the UI, allowing users to trigger the changelog generation process.

These changes shift the application's purpose from generating sales emails to creating changelogs, streamlining the codebase and user interface accordingly.
