### PR TITLE
Refactor OpenAI client initialization

### DIFF
--- a/changelog_generator/backend/backend.py
+++ b/changelog_generator/backend/backend.py
@@ -8,15 +8,17 @@ from sqlmodel import or_, select
 
 from .models import GithubPullRequest
 
-_client = None
+CLIENT_OPEN_AI = None
 
 
 def get_openai_client():
-    global _client
-    if _client is None:
-        _client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+    global CLIENT_OPEN_AI
+    if CLIENT_OPEN_AI is None:
+        CLIENT_OPEN_AI = openai.OpenAI(
+            api_key=os.environ["OPENAI_API_KEY"],
+        )
 
-    return _client
+    return CLIENT_OPEN_AI
 
 
 class State(rx.State):


### PR DESCRIPTION
This pull request refactors the OpenAI client initialization in the backend. It renames the global variable from `_client` to `CLIENT_OPEN_AI` for better clarity and consistency with naming conventions. The `get_openai_client()` function is updated to use this new variable name. Additionally, the OpenAI client initialization is now more explicit, with the API key passed as a named parameter.
