### PR TITLE
Add GitHub integration and refactor pull request model

### DIFF
--- a/changelog_generator/backend/backend.py
+++ b/changelog_generator/backend/backend.py
@@ -4,11 +4,26 @@ import os
 
 import openai
 import reflex as rx
+
+from github import Github
 from sqlmodel import or_, select
 
 from .models import GithubPullRequest
 
 CLIENT_OPEN_AI = None
+CLIENT_GITHUB = None
+
+
+def get_github_client():
+    global CLIENT_GITHUB
+    if CLIENT_GITHUB is None:
+        github_token = os.environ.get("GITHUB_TOKEN")
+        if not github_token:
+            raise ValueError("GITHUB_TOKEN environment variable is not set")
+
+        CLIENT_GITHUB = Github(github_token)
+
+    return CLIENT_GITHUB
 
 
 def get_openai_client():
@@ -30,7 +45,6 @@ class State(rx.State):
     release_tag_end: str = ""
     repository_url: str = ""
 
-    products: dict[str, str] = {}
     email_content_data: str = (
         "Click 'Generate Changelog' make an AI generated changelog."
     )
@@ -154,3 +168,40 @@ class State(rx.State):
         self.gen_response = True
         self.email_content_data = ""
         return State.call_openai
+
+    @rx.background
+    async def fetch_pull_requests_between_tags(
+        self,
+    ) -> list[GithubPullRequest]:
+        repo_url: str = self.repository_url
+        start_tag: str = self.release_tag_start
+        end_tag: str = self.release_tag_end
+        client = get_github_client()
+        repo = client.get_repo(repo_url)
+
+        # Get the commit SHAs for the start and end tags
+        start_commit = repo.get_git_ref(f"tags/{start_tag}").object.sha
+        end_commit = repo.get_git_ref(f"tags/{end_tag}").object.sha
+
+        # Get all pull requests between the two commits
+        pulls = repo.get_pulls(state="closed", sort="created", direction="desc")
+
+        pull_requests = []
+        for pr in pulls:
+            if pr.merge_commit_sha and (
+                repo.compare(start_commit, pr.merge_commit_sha).ahead_by >= 0
+                and repo.compare(pr.merge_commit_sha, end_commit).ahead_by >= 0
+            ):
+                pull_requests.append(
+                    GithubPullRequest(
+                        title=pr.title,
+                        number=pr.number,
+                        body=pr.body,
+                        author=pr.user.login,
+                        merged_at=pr.merged_at,
+                        url=pr.html_url,
+                    ),
+                )
+
+        self.pull_requests = pull_requests
+        return pull_requests

--- a/changelog_generator/backend/models.py
+++ b/changelog_generator/backend/models.py
@@ -6,10 +6,9 @@ class GithubPullRequest(
     table=True,
 ):  # type: ignore
 
-    customer_name: str
-    email: str
-    age: int
-    gender: str
-    location: str
-    job: str
-    salary: int
+    title: str
+    number: int
+    body: str
+    author: str
+    merged_at: str
+    url: str

--- a/changelog_generator/views/table.py
+++ b/changelog_generator/views/table.py
@@ -1,16 +1,13 @@
 import reflex as rx
 
 from changelog_generator.backend.backend import GithubPullRequest, State
-from changelog_generator.components.gender_badges import gender_badge
 
 
 def _header_cell(
     text: str,
-    icon: str,
 ):
     return rx.table.column_header_cell(
         rx.hstack(
-            rx.icon(icon, size=18),
             rx.text(text),
             align="center",
             spacing="2",
@@ -18,24 +15,16 @@ def _header_cell(
     )
 
 
-def _show_pull_request(pull_request: GithubPullRequest):
+def _show_pull_request(
+    pull_request: GithubPullRequest,
+):
     """Show a customer in a table row."""
     return rx.table.row(
-        rx.table.row_header_cell(pull_request.customer_name),
-        rx.table.cell(pull_request.email),
-        rx.table.cell(pull_request.age),
-        rx.table.cell(
-            rx.match(
-                pull_request.gender,
-                ("Male", gender_badge("Male")),
-                ("Female", gender_badge("Female")),
-                ("Other", gender_badge("Other")),
-                gender_badge("Other"),
-            ),
-        ),
-        rx.table.cell(pull_request.location),
-        rx.table.cell(pull_request.job),
-        rx.table.cell(pull_request.salary),
+        rx.table.row_header_cell(pull_request.number),
+        rx.table.cell(pull_request.author),
+        rx.table.cell(pull_request.title),
+        rx.table.cell(pull_request.merged_at),
+        rx.table.cell(pull_request.url),
         rx.table.cell(
             rx.icon_button(
                 rx.icon("trash-2", size=22),
@@ -93,14 +82,12 @@ def main_table():
         rx.table.root(
             rx.table.header(
                 rx.table.row(
-                    _header_cell("Name", "square-user-round"),
-                    _header_cell("Email", "mail"),
-                    _header_cell("Age", "person-standing"),
-                    _header_cell("Gender", "user-round"),
-                    _header_cell("Location", "map-pinned"),
-                    _header_cell("Job", "briefcase"),
-                    _header_cell("Salary", "dollar-sign"),
-                    _header_cell("Actions", "cog"),
+                    _header_cell("PR #"),
+                    _header_cell("Author"),
+                    _header_cell("Title"),
+                    _header_cell("Merged at"),
+                    _header_cell("URL"),
+                    _header_cell("Actions"),
                 ),
             ),
             rx.table.body(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 reflex>=v0.5.10
 openai>=1
+PyGithub


### PR DESCRIPTION
This pull request implements functionality to fetch GitHub pull requests between two specified tags. Key changes include:

1. Added a GitHub client initialization function using the GITHUB_TOKEN environment variable.
2. Implemented a new background task `fetch_pull_requests_between_tags` to retrieve pull requests between two given tags.
3. Updated the `GithubPullRequest` model to include relevant fields for pull request data.
4. Modified the table view to display pull request information instead of customer data.
5. Removed unused components and imports related to the previous customer data display.
6. Added PyGithub to the requirements.txt file for GitHub API integration.

These changes enable the application to fetch and display relevant pull request data for changelog generation.
